### PR TITLE
Refactor methods to improve code

### DIFF
--- a/src/Unosquare.DateTimeExt/Interfaces/ILinkedEntity.cs
+++ b/src/Unosquare.DateTimeExt/Interfaces/ILinkedEntity.cs
@@ -2,8 +2,8 @@
 
 public interface ILinkedEntity<out T>
 {
-    T Previous { get; }
-    T Next { get; }
+    T Previous(int offset = 1);
+    T Next(int offset = 1);
 
     bool IsCurrent { get; }
 }

--- a/src/Unosquare.DateTimeExt/Unosquare.DateTimeExt.csproj
+++ b/src/Unosquare.DateTimeExt/Unosquare.DateTimeExt.csproj
@@ -6,7 +6,7 @@
 		<Nullable>enable</Nullable>
 		<AnalysisLevel>latest</AnalysisLevel>
 		<CodeAnalysisRuleSet>..\..\StyleCop.Analyzers.ruleset</CodeAnalysisRuleSet>
-		<Version>1.5.4</Version>
+		<Version>2.0.0</Version>
 	</PropertyGroup>
 
 </Project>

--- a/src/Unosquare.DateTimeExt/YearAbstract.cs
+++ b/src/Unosquare.DateTimeExt/YearAbstract.cs
@@ -30,9 +30,9 @@ public abstract class YearAbstract<T> : DateRange, IHasReadOnlyYear, IHasMonths,
 
     public IReadOnlyCollection<int> Quarters { get; }
 
-    public abstract T Previous { get; }
+    public abstract T Previous(int offset = 1);
 
-    public abstract T Next { get; }
+    public abstract T Next(int offset = 1);
 
     public abstract bool IsCurrent { get; }
 }

--- a/src/Unosquare.DateTimeExt/YearEntity.cs
+++ b/src/Unosquare.DateTimeExt/YearEntity.cs
@@ -10,9 +10,9 @@ public sealed class YearEntity(int? year = null) : YearAbstract<YearEntity>(new(
 
     public static YearEntity Current => new();
 
-    public override YearEntity Next => new(StartDate.AddYears(1));
+    public override YearEntity Next(int offset = 1) => new(StartDate.AddYears(offset));
 
-    public override YearEntity Previous => new(StartDate.AddYears(-1));
+    public override YearEntity Previous(int offset = 1) => new(StartDate.AddYears(-offset));
 
     public override bool IsCurrent => IsCurrentYear;
 }

--- a/src/Unosquare.DateTimeExt/YearMonth.cs
+++ b/src/Unosquare.DateTimeExt/YearMonth.cs
@@ -34,9 +34,9 @@ public class YearMonth(int? month = null, int? year = null)
 
     public YearEntity YearEntity => new(Year);
 
-    public override YearMonth Next => new(StartDate.AddMonths(1));
+    public override YearMonth Next(int offset = 1) => new(StartDate.AddMonths(offset));
 
-    public override YearMonth Previous => new(StartDate.AddMonths(-1));
+    public override YearMonth Previous(int offset = 1) => new(StartDate.AddMonths(-offset));
 
     public override bool IsCurrent => Month == DateTime.UtcNow.Month && IsCurrentYear;
 

--- a/src/Unosquare.DateTimeExt/YearQuarter.cs
+++ b/src/Unosquare.DateTimeExt/YearQuarter.cs
@@ -34,9 +34,9 @@ public class YearQuarter : YearAbstract<YearQuarter>, IYearQuarterDateRange, ICo
 
     public YearEntity YearEntity => new(Year);
 
-    public override YearQuarter Next => new(StartDate.AddMonths(QuarterMonths));
+    public override YearQuarter Next(int offset = 1) => new(StartDate.AddMonths(QuarterMonths * offset));
 
-    public override YearQuarter Previous => new(StartDate.AddMonths(-QuarterMonths));
+    public override YearQuarter Previous(int offset = 1) => new(StartDate.AddMonths(-QuarterMonths * offset));
 
     public override bool IsCurrent => Quarter == DateTime.UtcNow.GetQuarter() && IsCurrentYear;
 

--- a/src/Unosquare.DateTimeExt/YearToDate.cs
+++ b/src/Unosquare.DateTimeExt/YearToDate.cs
@@ -31,9 +31,9 @@ public sealed class YearToDate : YearAbstract<YearToDate>, IHasReadOnlyMonth, IH
 
     public IReadOnlyCollection<YearQuarter> YearQuarters { get; }
 
-    public override YearToDate Previous => new(StartDate.AddYears(-1).Year);
+    public override YearToDate Previous(int offset = 1) => new(StartDate.AddYears(-offset).Year);
 
-    public override YearToDate Next => new(StartDate.AddYears(1).Year);
+    public override YearToDate Next(int offset = 1) => new(StartDate.AddYears(offset).Year);
 
     public override bool IsCurrent => IsCurrentYear;
 

--- a/src/Unosquare.DateTimeExt/YearWeek.cs
+++ b/src/Unosquare.DateTimeExt/YearWeek.cs
@@ -31,9 +31,9 @@ public sealed class YearWeek : YearWeekBase<YearWeek>, IComparable<YearWeek>
     public override int Week { get; }
     public override int Year => StartDate.Year;
 
-    public override YearWeek Next => new(StartDate.AddDays(WeekDays));
+    public override YearWeek Next(int offset = 1) => new(StartDate.AddDays(WeekDays * offset));
 
-    public override YearWeek Previous => new(StartDate.AddDays(-WeekDays));
+    public override YearWeek Previous(int offset = 1) => new(StartDate.AddDays(-WeekDays * offset));
 
     public override bool IsCurrent => IsCurrentYear && Week == DateTime.UtcNow.GetWeekOfYear();
 

--- a/src/Unosquare.DateTimeExt/YearWeekBase.cs
+++ b/src/Unosquare.DateTimeExt/YearWeekBase.cs
@@ -7,8 +7,8 @@ public abstract class YearWeekBase<T>(DateTime startDate, DateTime endDate)
 {
     protected const int WeekDays = 7;
 
-    public abstract T Previous { get; }
-    public abstract T Next { get; }
+    public abstract T Previous(int offset = 1);
+    public abstract T Next(int offset = 1);
     public abstract bool IsCurrent { get; }
     public abstract int Year { get; }
     public abstract int Week { get; }

--- a/src/Unosquare.DateTimeExt/YearWeekIso.cs
+++ b/src/Unosquare.DateTimeExt/YearWeekIso.cs
@@ -26,9 +26,9 @@ public sealed class YearWeekIso(int week, int year) : YearWeekBase<YearWeekIso>(
     public override int Week => ISOWeek.GetWeekOfYear(StartDate);
     public override int Year => ISOWeek.GetYear(StartDate);
 
-    public override YearWeekIso Next => new(StartDate.AddDays(WeekDays));
+    public override YearWeekIso Next(int offset = 1) => new(StartDate.AddDays(WeekDays * offset));
 
-    public override YearWeekIso Previous => new(StartDate.AddDays(-WeekDays));
+    public override YearWeekIso Previous(int offset = 1) => new(StartDate.AddDays(-WeekDays * offset));
 
     public override bool IsCurrent => IsCurrentYear && Week == ISOWeek.GetWeekOfYear(DateTime.UtcNow);
 

--- a/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearMonth-Tests.cs
+++ b/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearMonth-Tests.cs
@@ -23,7 +23,7 @@ public class YearMonthTests
     {
         var yearMonth = new YearMonth(month: 1, year: 2022);
 
-        Assert.Equal(new(2022, 2, 1), yearMonth.Next.StartDate);
+        Assert.Equal(new(2022, 2, 1), yearMonth.Next().StartDate);
     }
 
     [Fact]
@@ -31,7 +31,7 @@ public class YearMonthTests
     {
         var yearMonth = new YearMonth(month: 2, year: 2022);
 
-        Assert.Equal(new(2022, 1, 1), yearMonth.Previous.StartDate);
+        Assert.Equal(new(2022, 1, 1), yearMonth.Previous().StartDate);
     }
 
     [Fact]

--- a/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearToDate-Tests.cs
+++ b/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearToDate-Tests.cs
@@ -109,4 +109,22 @@ public class YearToDateTests
         Assert.Equal(12, yearMonths.Count);
         Assert.Equal(new(2021, 1, 1), yearMonths.First().StartDate);
     }
+
+    [Fact]
+    public void YearToDate_Previous()
+    {
+        var yearToDate = new YearToDate(2021);
+        var previousYearToDate = yearToDate.Previous();
+
+        Assert.Equal(2020, previousYearToDate.Year);
+    }
+
+    [Fact]
+    public void YearToDate_Next()
+    {
+        var yearToDate = new YearToDate(2021);
+        var nextYearToDate = yearToDate.Next();
+
+        Assert.Equal(2022, nextYearToDate.Year);
+    }
 }

--- a/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearWeek-Tests.cs
+++ b/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearWeek-Tests.cs
@@ -51,7 +51,7 @@ public class YearWeekTests
     {
         var yearMonth = new YearWeek(2, 2022);
 
-        Assert.Equal(new(2022, 1, 2), yearMonth.Previous.StartDate);
+        Assert.Equal(new(2022, 1, 2), yearMonth.Previous().StartDate);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class YearWeekTests
     {
         var yearMonth = new YearWeek(1, 2022);
 
-        Assert.Equal(new(2022, 1, 9), yearMonth.Next.StartDate);
+        Assert.Equal(new(2022, 1, 9), yearMonth.Next().StartDate);
     }
 
     [Fact]

--- a/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearWeekIsoTests.cs
+++ b/test/Unosquare.DateTimeExt.Test/Unosquare.DateTimeExt.Test/YearWeekIsoTests.cs
@@ -51,7 +51,7 @@ public class YearWeekIsoTests
     {
         var yearMonth = new YearWeekIso(2, 2022);
 
-        Assert.Equal(new(2022, 1, 3), yearMonth.Previous.StartDate);
+        Assert.Equal(new(2022, 1, 3), yearMonth.Previous().StartDate);
     }
 
     [Fact]
@@ -59,7 +59,7 @@ public class YearWeekIsoTests
     {
         var yearMonth = new YearWeekIso(1, 2022);
 
-        Assert.Equal(new(2022, 1, 10), yearMonth.Next.StartDate);
+        Assert.Equal(new(2022, 1, 10), yearMonth.Next().StartDate);
     }
 
     [Fact]


### PR DESCRIPTION
Refactor code to change `Next` and `Previous` properties to methods with an optional `offset` parameter.

* **Interfaces/ILinkedEntity.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearAbstract.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearEntity.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearMonth.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearQuarter.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearToDate.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearWeek.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearWeekBase.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **YearWeekIso.cs**
  - Change `Previous` property to `Previous(int offset = 1)` method
  - Change `Next` property to `Next(int offset = 1)` method

* **Unit Tests**
  - Update tests in `YearMonth-Tests.cs`, `YearQuarter-Tests.cs`, `YearToDate-Tests.cs`, `YearWeek-Tests.cs`, and `YearWeekIsoTests.cs` to use `Previous(int offset = 1)` and `Next(int offset = 1)` methods

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/unosquare/unodatetime/pull/13?shareId=3596eb97-d3d4-4048-8d78-30a63e03a6f9).